### PR TITLE
(breaking:md) change social_media to web_links

### DIFF
--- a/contributors/tanner-dolby/index.md
+++ b/contributors/tanner-dolby/index.md
@@ -5,7 +5,7 @@ is_featured: true
 profile_img:
     - src: profile-image.jpg
       alt: Tanner Dolby smiling and holding a water bottle in his right hand
-social_media:
+web_links:
     - name: GitHub
       url: https://github.com/tannerdolby
     - name: Twitter


### PR DESCRIPTION
Change the `social_media` frontmatter entry to `web_links` as not all links are social media links.
