### PR TITLE
ci(CODEOWNERS): add owners for all unowned paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,17 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
-/.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/engineering
+* @mdn/content-team
+
+# Directories
+/.github      @mdn/engineering
+/contributors @mdn/content-team
+
+# GitHub templates
+/.github/ISSUE_TEMPLATE/       @mdn/content-team
+/.github/PULL_REQUEST_TEMPLATE @mdn/content-team
+
+# Root directory
+/*           @mdn/engineering
+/*.md        @mdn/content-team
 /SECURITY.md @mdn/engineering


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds code owners for all currently unowned paths.

### Motivation

Ensure that reviewers are automatically assigned on PRs, and changes only land with approval.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/curriculum/pull/105
- https://github.com/mdn/generic-content/pull/27
